### PR TITLE
Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/src/main/java/biweekly/component/VAlarm.java
+++ b/src/main/java/biweekly/component/VAlarm.java
@@ -570,9 +570,9 @@ public class VAlarm extends ICalComponent {
 					boolean noEndDate = false;
 
 					if (parent instanceof VEvent) {
-						noEndDate = (parent.getProperty(DateEnd.class) == null && (parent.getProperty(DateStart.class) == null || parent.getProperty(DurationProperty.class) == null));
+						noEndDate = parent.getProperty(DateEnd.class) == null && (parent.getProperty(DateStart.class) == null || parent.getProperty(DurationProperty.class) == null);
 					} else if (parent instanceof VTodo) {
-						noEndDate = (parent.getProperty(DateDue.class) == null && (parent.getProperty(DateStart.class) == null || parent.getProperty(DurationProperty.class) == null));
+						noEndDate = parent.getProperty(DateDue.class) == null && (parent.getProperty(DateStart.class) == null || parent.getProperty(DurationProperty.class) == null);
 					}
 
 					if (noEndDate) {

--- a/src/main/java/biweekly/io/json/JsonValue.java
+++ b/src/main/java/biweekly/io/json/JsonValue.java
@@ -68,7 +68,7 @@ public class JsonValue {
 		this.object = object;
 		value = null;
 		array = null;
-		isNull = (object == null);
+		isNull = object == null;
 	}
 
 	/**

--- a/src/main/java/biweekly/io/scribe/property/ExceptionDatesScribe.java
+++ b/src/main/java/biweekly/io/scribe/property/ExceptionDatesScribe.java
@@ -66,7 +66,7 @@ public class ExceptionDatesScribe extends ListPropertyScribe<ExceptionDates, ICa
 		if (property.getValues().isEmpty()) {
 			hasTime = false;
 		} else {
-			hasTime = (dataType(property, context.getVersion()) == DATE_TIME);
+			hasTime = dataType(property, context.getVersion()) == DATE_TIME;
 		}
 		return handleTzidParameter(property, hasTime, context);
 	}
@@ -99,7 +99,7 @@ public class ExceptionDatesScribe extends ListPropertyScribe<ExceptionDates, ICa
 	protected ICalDate readValue(ExceptionDates property, String value, ICalDataType dataType, ICalParameters parameters, ParseContext context) {
 		ICalDate date;
 		try {
-			boolean hasTime = (dataType == DATE_TIME);
+			boolean hasTime = dataType == DATE_TIME;
 			date = date(value).hasTime(hasTime).parse();
 		} catch (IllegalArgumentException e) {
 			throw new CannotParseException(19);

--- a/src/main/java/biweekly/io/scribe/property/RecurrenceDatesScribe.java
+++ b/src/main/java/biweekly/io/scribe/property/RecurrenceDatesScribe.java
@@ -68,7 +68,7 @@ public class RecurrenceDatesScribe extends ICalPropertyScribe<RecurrenceDates> {
 			hasTime = false;
 		} else {
 			ICalDataType dataType = dataType(property, context.getVersion());
-			hasTime = (dataType == DATE_TIME || dataType == PERIOD);
+			hasTime = dataType == DATE_TIME || dataType == PERIOD;
 		}
 		return handleTzidParameter(property, hasTime, context);
 	}
@@ -356,7 +356,7 @@ public class RecurrenceDatesScribe extends ICalPropertyScribe<RecurrenceDates> {
 		}
 
 		//parse as dates
-		boolean hasTime = (dataType == DATE_TIME);
+		boolean hasTime = dataType == DATE_TIME;
 		for (String valueStr : valueStrs) {
 			ICalDate date;
 			try {

--- a/src/main/java/biweekly/io/text/ICalRawWriter.java
+++ b/src/main/java/biweekly/io/text/ICalRawWriter.java
@@ -307,7 +307,7 @@ public class ICalRawWriter implements Closeable, Flushable {
 		 * Determine if the property value must be encoded in quoted printable
 		 * encoding. If so, then determine what charset to use for the encoding.
 		 */
-		boolean useQuotedPrintable = (parameters.getEncoding() == Encoding.QUOTED_PRINTABLE);
+		boolean useQuotedPrintable = parameters.getEncoding() == Encoding.QUOTED_PRINTABLE;
 		Charset quotedPrintableCharset = null;
 		if (useQuotedPrintable) {
 			String charsetParam = parameters.getCharset();
@@ -381,7 +381,7 @@ public class ICalRawWriter implements Closeable, Flushable {
 			return false;
 		}
 		char first = string.charAt(0);
-		return (first == ' ' || first == '\t');
+		return first == ' ' || first == '\t';
 	}
 
 	/**

--- a/src/main/java/biweekly/util/DateTimeComponents.java
+++ b/src/main/java/biweekly/util/DateTimeComponents.java
@@ -105,7 +105,7 @@ public final class DateTimeComponents implements Comparable<DateTimeComponents>,
 
 		String hourStr = m.group(i++);
 		if (hasTime == null) {
-			hasTime = (hourStr != null);
+			hasTime = hourStr != null;
 		}
 		if (!hasTime) {
 			return new DateTimeComponents(year, month, date);

--- a/src/main/java/biweekly/util/UtcOffset.java
+++ b/src/main/java/biweekly/util/UtcOffset.java
@@ -124,7 +124,7 @@ public final class UtcOffset {
 	public String toString(boolean extended) {
 		StringBuilder sb = new StringBuilder();
 
-		boolean positive = (millis >= 0);
+		boolean positive = millis >= 0;
 		long hour = Math.abs(millisToHours(millis));
 		long minute = Math.abs(millisToMinutes(millis));
 

--- a/src/main/java/com/google/ical/iter/Filters.java
+++ b/src/main/java/com/google/ical/iter/Filters.java
@@ -74,7 +74,7 @@ class Filters {
           if (wkst.javaDayNum <= dow.javaDayNum) {
             dateWeekNo = 1 + (instance / 7);
           } else {
-            dateWeekNo = (instance / 7);
+            dateWeekNo = instance / 7;
           }
 
           // TODO(msamuel): according to section 4.3.10

--- a/src/main/java/com/google/ical/iter/Generators.java
+++ b/src/main/java/com/google/ical/iter/Generators.java
@@ -211,7 +211,7 @@ final class Generators {
             || year != builder.year) {
           int hoursBetween = daysBetween(
               builder, year, month, day) * 24 - hour;
-          nhour = ((interval - (hoursBetween % interval)) % interval);
+          nhour = (interval - (hoursBetween % interval)) % interval;
           if (nhour > 23) {
             // Don't update day so that the difference calculation above is
             // correct when this function is reentered with a different day
@@ -263,7 +263,7 @@ final class Generators {
           int minutesBetween = (daysBetween(
               builder, year, month, day) * 24 + builder.hour - hour) * 60
               - minute;
-          nminute = ((interval - (minutesBetween % interval)) % interval);
+          nminute = (interval - (minutesBetween % interval)) % interval;
           if (nminute > 59) {
             // Don't update day so that the difference calculation above is
             // correct when this function is reentered with a different day
@@ -322,7 +322,7 @@ final class Generators {
           int secondsBetween = ((daysBetween(
               builder, year, month, day) * 24 + builder.hour - hour) * 60
               + builder.minute - minute) * 60 - second ;
-          nsecond = ((interval - (secondsBetween % interval)) % interval);
+          nsecond = (interval - (secondsBetween % interval)) % interval;
           if (nsecond > 59) {
             // Don't update day so that the difference calculation above is
             // correct when this function is reentered with a different day

--- a/src/main/java/com/google/ical/util/TimeUtils.java
+++ b/src/main/java/com/google/ical/util/TimeUtils.java
@@ -277,8 +277,8 @@ public class TimeUtils {
    * is not a TimeValue.
    */
   public static DateValue toDateValue(DateValue dv) {
-    return (!(dv instanceof TimeValue) ? dv
-            : new DateValueImpl(dv.year(), dv.month(), dv.day()));
+    return !(dv instanceof TimeValue) ? dv
+            : new DateValueImpl(dv.year(), dv.month(), dv.day());
   }
 
   private static final TimeZone BOGUS_TIMEZONE =

--- a/src/main/java/com/google/ical/values/RRule.java
+++ b/src/main/java/com/google/ical/values/RRule.java
@@ -190,7 +190,7 @@ public class RRule extends AbstractIcalObject {
     }
     if (0 == nPerPeriod) { nPerPeriod = 1; }
 
-    return ((freqLengthDays / nPerPeriod) * this.interval);
+    return (freqLengthDays / nPerPeriod) * this.interval;
   }
 
   /** the frequency of repetition */


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule

squid:UselessParenthesesCheck - CUseless parentheses around expressions should be removed to prevent any misunderstanding

https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.
Zeeshan Asghar