### PR TITLE
Array designators [] should be on the type, not the variable

### DIFF
--- a/src/main/java/biweekly/component/VEvent.java
+++ b/src/main/java/biweekly/component/VEvent.java
@@ -1607,7 +1607,7 @@ public class VEvent extends ICalComponent {
 
 		checkOptionalCardinality(warnings, Color.class);
 
-		Status validStatuses[];
+		Status[] validStatuses;
 		switch (version) {
 		case V1_0:
 			validStatuses = new Status[] { Status.tentative(), Status.confirmed(), Status.declined(), Status.needsAction(), Status.sent(), Status.delegated() };

--- a/src/main/java/biweekly/component/VTodo.java
+++ b/src/main/java/biweekly/component/VTodo.java
@@ -1641,7 +1641,7 @@ public class VTodo extends ICalComponent {
 
 		checkOptionalCardinality(warnings, Color.class);
 
-		Status validStatuses[];
+		Status[] validStatuses;
 		switch (version) {
 		case V1_0:
 			validStatuses = new Status[] { Status.needsAction(), Status.completed(), Status.accepted(), Status.declined(), Status.delegated(), Status.sent() };

--- a/src/main/java/biweekly/io/DataModelConverter.java
+++ b/src/main/java/biweekly/io/DataModelConverter.java
@@ -333,7 +333,7 @@ public class DataModelConverter {
 	private static Attachment buildAttachment(AudioAlarm aalarm) {
 		String type = aalarm.getParameter("TYPE");
 		String contentType = (type == null) ? null : "audio/" + type.toLowerCase();
-		byte data[] = aalarm.getData();
+		byte[] data = aalarm.getData();
 		if (data != null) {
 			return new Attachment(contentType, data);
 		}

--- a/src/main/java/biweekly/io/scribe/property/AudioAlarmScribe.java
+++ b/src/main/java/biweekly/io/scribe/property/AudioAlarmScribe.java
@@ -63,7 +63,7 @@ public class AudioAlarmScribe extends VCalAlarmPropertyScribe<AudioAlarm> {
 			return Arrays.asList(uri);
 		}
 
-		byte data[] = property.getData();
+		byte[] data = property.getData();
 		if (data != null) {
 			String base64Str = Base64.encodeBase64String(data);
 			return Arrays.asList(base64Str);

--- a/src/main/java/biweekly/io/scribe/property/BinaryPropertyScribe.java
+++ b/src/main/java/biweekly/io/scribe/property/BinaryPropertyScribe.java
@@ -76,7 +76,7 @@ public abstract class BinaryPropertyScribe<T extends BinaryProperty> extends ICa
 			return uri;
 		}
 
-		byte data[] = property.getData();
+		byte[] data = property.getData();
 		if (data != null) {
 			return Base64.encodeBase64String(data);
 		}
@@ -107,7 +107,7 @@ public abstract class BinaryPropertyScribe<T extends BinaryProperty> extends ICa
 			return;
 		}
 
-		byte data[] = property.getData();
+		byte[] data = property.getData();
 		if (data != null) {
 			element.append(ICalDataType.BINARY, Base64.encodeBase64String(data));
 			return;
@@ -139,7 +139,7 @@ public abstract class BinaryPropertyScribe<T extends BinaryProperty> extends ICa
 			return JCalValue.single(uri);
 		}
 
-		byte data[] = property.getData();
+		byte[] data = property.getData();
 		if (data != null) {
 			return JCalValue.single(Base64.encodeBase64String(data));
 		}

--- a/src/main/java/biweekly/io/scribe/property/RecurrencePropertyScribe.java
+++ b/src/main/java/biweekly/io/scribe/property/RecurrencePropertyScribe.java
@@ -225,7 +225,7 @@ public abstract class RecurrencePropertyScribe<T extends RecurrenceProperty> ext
 			return property;
 		}
 
-		String splitValues[] = value.toUpperCase().split("\\s+");
+		String[] splitValues = value.toUpperCase().split("\\s+");
 
 		//parse the frequency and interval from the first token (e.g. "W2")
 		String frequencyStr;

--- a/src/main/java/biweekly/parameter/VersionedEnumParameterValue.java
+++ b/src/main/java/biweekly/parameter/VersionedEnumParameterValue.java
@@ -37,8 +37,8 @@ import biweekly.ICalVersion;
  * @author Michael Angstadt
  */
 public class VersionedEnumParameterValue extends EnumParameterValue {
-	private static final ICalVersion allVersions[] = ICalVersion.values();
-	protected final ICalVersion supportedVersions[];
+	private static final ICalVersion[] allVersions = ICalVersion.values();
+	protected final ICalVersion[] supportedVersions;
 
 	public VersionedEnumParameterValue(String value, ICalVersion... supportedVersions) {
 		super(value);

--- a/src/main/java/biweekly/util/org/apache/commons/codec/binary/BaseNCodecInputStream.java
+++ b/src/main/java/biweekly/util/org/apache/commons/codec/binary/BaseNCodecInputStream.java
@@ -79,7 +79,7 @@ public class BaseNCodecInputStream extends FilterInputStream {
      *             if offset, len or buffer size are invalid
      */
     @Override
-    public int read(byte b[], int offset, int len) throws IOException {
+    public int read(byte[] b, int offset, int len) throws IOException {
         if (b == null) {
             throw new NullPointerException();
         } else if (offset < 0 || len < 0) {

--- a/src/main/java/biweekly/util/org/apache/commons/codec/binary/BaseNCodecOutputStream.java
+++ b/src/main/java/biweekly/util/org/apache/commons/codec/binary/BaseNCodecOutputStream.java
@@ -73,7 +73,7 @@ public class BaseNCodecOutputStream extends FilterOutputStream {
      *             if offset, len or buffer size are invalid
      */
     @Override
-    public void write(byte b[], int offset, int len) throws IOException {
+    public void write(byte[] b, int offset, int len) throws IOException {
         if (b == null) {
             throw new NullPointerException();
         } else if (offset < 0 || len < 0) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1197  Array designators [] should be on the type, not the variable

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1197

Please let me know if you have any questions.

Zeeshan Asghar