### PR TITLE
Private methods that dont access instance data should be static

### DIFF
--- a/src/main/java/biweekly/io/TimezoneInfo.java
+++ b/src/main/java/biweekly/io/TimezoneInfo.java
@@ -291,7 +291,7 @@ public class TimezoneInfo {
 		}
 	}
 
-	private <T> void removeIdentity(List<T> list, T object) {
+	private static <T> void removeIdentity(List<T> list, T object) {
 		Iterator<T> it = list.iterator();
 		while (it.hasNext()) {
 			if (object == it.next()) {
@@ -300,7 +300,7 @@ public class TimezoneInfo {
 		}
 	}
 
-	private <T> boolean containsIdentity(List<T> list, T object) {
+	private static <T> boolean containsIdentity(List<T> list, T object) {
 		for (T item : list) {
 			if (item == object) {
 				return true;

--- a/src/main/java/biweekly/io/TzUrlDotOrgGenerator.java
+++ b/src/main/java/biweekly/io/TzUrlDotOrgGenerator.java
@@ -117,7 +117,7 @@ public class TzUrlDotOrgGenerator implements VTimezoneGenerator {
 		}
 	}
 
-	private IllegalArgumentException notFound(Exception e) {
+	private static IllegalArgumentException notFound(Exception e) {
 		return new IllegalArgumentException("Timezone ID not recognized.", e);
 	}
 }

--- a/src/main/java/biweekly/io/scribe/property/RecurrencePropertyScribe.java
+++ b/src/main/java/biweekly/io/scribe/property/RecurrencePropertyScribe.java
@@ -426,7 +426,7 @@ public abstract class RecurrencePropertyScribe<T extends RecurrenceProperty> ext
 		return property;
 	}
 
-	private int parseVCalInt(String value) {
+	private static int parseVCalInt(String value) {
 		int negate = 1;
 		if (value.endsWith("+")) {
 			value = value.substring(0, value.length() - 1);
@@ -438,7 +438,7 @@ public abstract class RecurrencePropertyScribe<T extends RecurrenceProperty> ext
 		return Integer.parseInt(value) * negate;
 	}
 
-	private String writeVCalInt(Integer value) {
+	private static String writeVCalInt(Integer value) {
 		if (value > 0) {
 			return value + "+";
 		}

--- a/src/main/java/biweekly/io/scribe/property/RequestStatusScribe.java
+++ b/src/main/java/biweekly/io/scribe/property/RequestStatusScribe.java
@@ -103,7 +103,7 @@ public class RequestStatusScribe extends ICalPropertyScribe<RequestStatus> {
 		return requestStatus;
 	}
 
-	private String s(String str) {
+	private static String s(String str) {
 		return (str == null || str.length() == 0) ? null : str;
 	}
 

--- a/src/main/java/biweekly/io/text/ICalRawReader.java
+++ b/src/main/java/biweekly/io/text/ICalRawReader.java
@@ -461,11 +461,11 @@ public class ICalRawReader implements Closeable {
 		return reader.read();
 	}
 
-	private boolean isNewline(char ch) {
+	private static boolean isNewline(char ch) {
 		return ch == '\n' || ch == '\r';
 	}
 
-	private boolean isWhitespace(char ch) {
+	private static boolean isWhitespace(char ch) {
 		return ch == ' ' || ch == '\t';
 	}
 

--- a/src/main/java/biweekly/io/text/ICalRawWriter.java
+++ b/src/main/java/biweekly/io/text/ICalRawWriter.java
@@ -376,7 +376,7 @@ public class ICalRawWriter implements Closeable, Flushable {
 	 * @param string the string
 	 * @return true if it starts with whitespace, false if not
 	 */
-	private boolean beginsWithWhitespace(String string) {
+	private static boolean beginsWithWhitespace(String string) {
 		if (string.length() == 0) {
 			return false;
 		}
@@ -442,7 +442,7 @@ public class ICalRawWriter implements Closeable, Flushable {
 		}
 	}
 
-	private String printableCharacterList(String list) {
+	private static String printableCharacterList(String list) {
 		return list.replace("\n", "\\n").replace("\r", "\\r");
 	}
 

--- a/src/main/java/biweekly/io/xml/XCalWriter.java
+++ b/src/main/java/biweekly/io/xml/XCalWriter.java
@@ -517,7 +517,7 @@ public class XCalWriter extends XCalWriterBase {
 		handler.characters(text.toCharArray(), 0, text.length());
 	}
 
-	private Attributes getElementAttributes(Element element) {
+	private static Attributes getElementAttributes(Element element) {
 		AttributesImpl attributes = new AttributesImpl();
 		NamedNodeMap attributeNodes = element.getAttributes();
 		for (int i = 0; i < attributeNodes.getLength(); i++) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S2325  private methods that dont access instance data should be static

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2325

Please let me know if you have any questions.

Zeeshan Asghar