### PR TITLE
Fields in a Serializable class should either be transient or serializable

### DIFF
--- a/src/main/java/biweekly/Messages.java
+++ b/src/main/java/biweekly/Messages.java
@@ -36,7 +36,7 @@ import java.util.ResourceBundle;
 public enum Messages {
 	INSTANCE;
 
-	private final ResourceBundle messages;
+	private final transient ResourceBundle messages;
 
 	private Messages() {
 		messages = ResourceBundle.getBundle("biweekly/messages");

--- a/src/main/java/biweekly/Warning.java
+++ b/src/main/java/biweekly/Warning.java
@@ -1,5 +1,7 @@
 package biweekly;
 
+import java.io.Serializable;
+
 /*
  Copyright (c) 2013-2016, Michael Angstadt
  All rights reserved.
@@ -29,8 +31,11 @@ package biweekly;
  * Represents a warning.
  * @author Michael Angstadt
  */
-public class Warning {
-	private final Integer code;
+public class Warning implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    
+    private final Integer code;
 	private final String message;
 
 	/**

--- a/src/main/java/biweekly/component/VTimezone.java
+++ b/src/main/java/biweekly/component/VTimezone.java
@@ -1,5 +1,6 @@
 package biweekly.component;
 
+import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 
@@ -71,8 +72,11 @@ import biweekly.property.TimezoneUrl;
  * getter/setter method Javadocs because vCal does not use the VTIMEZONE
  * component.
  */
-public class VTimezone extends ICalComponent {
-	/**
+public class VTimezone extends ICalComponent implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
 	 * Creates a new timezone component.
 	 * @param identifier a unique identifier for this timezone (allows it to be
 	 * referenced by date-time properties that support timezones).

--- a/src/main/java/com/google/ical/util/Predicate.java
+++ b/src/main/java/com/google/ical/util/Predicate.java
@@ -2,10 +2,12 @@
 
 package com.google.ical.util;
 
+import java.io.Serializable;
+
 /**
  * A function with a boolean return value useful for filtering.
  */
-public interface Predicate<T> {
+public interface Predicate<T> extends Serializable {
 
   /**
    * Applies this Predicate to the given object.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1948  Fields in a Serializable class should either be transient or serializable

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1948

Please let me know if you have any questions.

Zeeshan Asghar