### PR TITLE
General Code Improvement 1

### DIFF
--- a/src/main/java/biweekly/io/DataModelConverter.java
+++ b/src/main/java/biweekly/io/DataModelConverter.java
@@ -73,6 +73,11 @@ import com.google.ical.values.DateTimeValue;
  * @author Michael Angstadt
  */
 public class DataModelConverter {
+    
+    private DataModelConverter() {
+        throw new AssertionError("Must not instantiate this class");
+    }
+    
 	/**
 	 * Converts vCalendar timezone information to am iCalendar {@link VTimezone}
 	 * component.

--- a/src/main/java/biweekly/util/org/apache/commons/codec/CharEncoding.java
+++ b/src/main/java/biweekly/util/org/apache/commons/codec/CharEncoding.java
@@ -53,6 +53,11 @@ package biweekly.util.org.apache.commons.codec;
  * @version $Id: CharEncoding.java 1170351 2011-09-13 21:09:09Z ggregory $
  */
 public class CharEncoding {
+    
+    private CharEncoding() {
+        throw new AssertionError("Must not instantiate this class");
+    } 
+    
     /**
      * CharEncodingISO Latin Alphabet No. 1, a.k.a. ISO-LATIN-1. </p>
      * <p>

--- a/src/main/java/biweekly/util/org/apache/commons/codec/StringEncoderComparator.java
+++ b/src/main/java/biweekly/util/org/apache/commons/codec/StringEncoderComparator.java
@@ -41,6 +41,7 @@ public class StringEncoderComparator implements Comparator {
      * @deprecated Creating an instance without a {@link StringEncoder} leads to a {@link NullPointerException}. Will be
      *             removed in 2.0.
      */
+    @Deprecated
     public StringEncoderComparator() {
         this.stringEncoder = null; // Trying to use this will cause things to break
     }

--- a/src/main/java/biweekly/util/org/apache/commons/codec/binary/Base64.java
+++ b/src/main/java/biweekly/util/org/apache/commons/codec/binary/Base64.java
@@ -477,6 +477,7 @@ public class Base64 extends BaseNCodec {
      *         <code>false</code>, otherwise
      * @deprecated 1.5 Use {@link #isBase64(byte[])}, will be removed in 2.0.
      */
+    @Deprecated
     public static boolean isArrayByteBase64(byte[] arrayOctet) {
         return isBase64(arrayOctet);
     }

--- a/src/main/java/biweekly/util/org/apache/commons/codec/binary/StringUtils.java
+++ b/src/main/java/biweekly/util/org/apache/commons/codec/binary/StringUtils.java
@@ -32,6 +32,10 @@ import biweekly.util.org.apache.commons.codec.CharEncoding;
  * @since 1.4
  */
 public class StringUtils {
+    
+    private StringUtils() {
+        throw new AssertionError("Must not instantiate this class");
+    }
 
     /**
      * Encodes the given string into a sequence of bytes using the ISO-8859-1 charset, storing the result into a new

--- a/src/main/java/biweekly/util/org/apache/commons/codec/net/URLCodec.java
+++ b/src/main/java/biweekly/util/org/apache/commons/codec/net/URLCodec.java
@@ -355,6 +355,7 @@ public class URLCodec implements BinaryEncoder, BinaryDecoder, StringEncoder, St
      * 
      * @deprecated Use {@link #getDefaultCharset()}, will be removed in 2.0.
      */
+    @Deprecated
     public String getEncoding() {
         return this.charset;
     }

--- a/src/main/java/biweekly/util/org/apache/commons/codec/net/Utils.java
+++ b/src/main/java/biweekly/util/org/apache/commons/codec/net/Utils.java
@@ -27,6 +27,10 @@ import biweekly.util.org.apache.commons.codec.DecoderException;
  * @since 1.4
  */
 class Utils {
+    
+    private Utils() {
+        throw new AssertionError("Must not instantiate this class");
+    }
 
     /**
      * Returns the numeric value of the character <code>b</code> in radix 16.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1118  Utility classes should not have public constructors
squid:MissingDeprecatedCheck  Deprecated elements should have both the annotation and the Javadoc tag

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck

Please let me know if you have any questions.

Zeeshan Asghar