### PR TITLE
Account for Daylight Savings Time gap hour

### DIFF
--- a/src/main/java/com/google/ical/util/TimeUtils.java
+++ b/src/main/java/com/google/ical/util/TimeUtils.java
@@ -83,7 +83,9 @@ public class TimeUtils {
     int millisecondOffset = zone.getOffset(timetMillis);
     int millisecondRound = millisecondOffset < 0 ? -500 : 500;
     int secondOffset = (millisecondOffset + millisecondRound) / 1000;
-    return addSeconds(time, sense * secondOffset);
+
+    DateTimeValue dtv = toDateTimeValue(timetMillis, zone);
+    return addSeconds(dtv, sense * secondOffset);
   }
 
   public static DateValue fromUtc(DateValue date, TimeZone zone) {
@@ -312,6 +314,19 @@ public class TimeUtils {
       return null;
     }
     return tz;
+  }
+
+  public static DateTimeValue toDateTimeValue(long millisFromEpoch, TimeZone zone) {
+    GregorianCalendar c = new GregorianCalendar(zone);
+    c.clear();
+    c.setTimeInMillis(millisFromEpoch);
+    return new DateTimeValueImpl (
+            c.get(Calendar.YEAR),
+            c.get(Calendar.MONTH) + 1,
+            c.get(Calendar.DAY_OF_MONTH),
+            c.get(Calendar.HOUR_OF_DAY),
+            c.get(Calendar.MINUTE),
+            c.get(Calendar.SECOND));
   }
 
   private TimeUtils() {

--- a/src/test/java/biweekly/property/RecurrencePropertyTest.java
+++ b/src/test/java/biweekly/property/RecurrencePropertyTest.java
@@ -94,8 +94,33 @@ public class RecurrencePropertyTest {
 		//@formatter:off
 		List<Date> expected = Arrays.asList(
 			date("2016-03-06 02:30:00", pacificTimeZone),
-			date("2016-03-13 01:30:00", pacificTimeZone), //TODO is this correct? https://github.com/mangstadt/biweekly/issues/38
+			date("2016-03-13 03:30:00", pacificTimeZone),
 			date("2016-03-20 02:30:00", pacificTimeZone)
+		);
+		//@formatter:on
+
+		List<Date> actual = new ArrayList<Date>();
+		DateIterator it = property.getDateIterator(start, pacificTimeZone);
+		while (it.hasNext()) {
+			actual.add(it.next());
+		}
+
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void getDateIterator_overlap_hour() {
+		TimeZone pacificTimeZone = TimeZone.getTimeZone("America/Los_Angeles");
+		Recurrence recur = new Recurrence.Builder(Frequency.WEEKLY).interval(1).count(3).build();
+		Date start = date("2016-10-30 01:30:00", pacificTimeZone);
+		RecurrenceProperty property = new RecurrenceProperty(recur);
+
+		//@formatter:off
+		// First date will be in PDT while the second and third are PST.
+		List<Date> expected = Arrays.asList(
+				date("2016-10-30 01:30:00", pacificTimeZone),
+				date("2016-11-06 01:30:00", pacificTimeZone),
+				date("2016-11-13 01:30:00", pacificTimeZone)
 		);
 		//@formatter:on
 


### PR DESCRIPTION
Resolves Issue #38 

In static method `convert` in TimeUtils.java, a new `DateTimeValue` is created using the milliseconds since the Epoch and the time zone passed into the `convert` method. The `DateTimeValue` returned is passed into method `addSecond` instead of the original `DateTimeValue` passed into `convert`.

* Fixes handling of daylight savings time "gap" hour
* Added unit test for daylight savings time overlap hour