### PR TITLE
Modify logic in Convert Method of TimeUtils.java

### DIFF
--- a/src/main/java/biweekly/util/com/google/ical/util/TimeUtils.java
+++ b/src/main/java/biweekly/util/com/google/ical/util/TimeUtils.java
@@ -71,22 +71,19 @@ public class TimeUtils {
     }
 
     long timetMillis;
+    DateTimeValue dtv;
 
     if (sense > 0) {
-      // time is in UTC
+      // time is in UTC; Convert to time in zone provided.
       timetMillis = timetMillisFromEpochSecs(secsSinceEpoch(time), ZULU);
+      dtv = toDateTimeValue(timetMillis, zone);
     } else {
-      // time is in local time; since zone.getOffset() expects millis
-      // in UTC, need to convert before we can get the offset (ironic)
+      // time is in local time; convert to UTC
       timetMillis = timetMillisFromEpochSecs(secsSinceEpoch(time), zone);
+      dtv = toDateTimeValue(timetMillis, ZULU);
     }
 
-    int millisecondOffset = zone.getOffset(timetMillis);
-    int millisecondRound = millisecondOffset < 0 ? -500 : 500;
-    int secondOffset = (millisecondOffset + millisecondRound) / 1000;
-
-    DateTimeValue dtv = toDateTimeValue(timetMillis, zone);
-    return addSeconds(dtv, sense * secondOffset);
+    return dtv;
   }
 
   public static DateValue fromUtc(DateValue date, TimeZone zone) {


### PR DESCRIPTION
Fixes #49 

The logic for converting to UTC from a local time and from UTC to a local time in method `TimeUtils.convert` has been updated. Once the milliseconds from the Epoch has been obtained, those milliseconds and the relevant timezone are passed to method `toDateTimeValue(long millisFromEpoch, TimeZone zone)` in `TimeUtils.java` for conversion to a `DateTimeValue` type. That method converts the milliseconds from the Epoch into a `GregorianCalendar` type first. This steps takes care of all timezone offsets adjustments as well as handling the DST "gap" and "overlap" hours when applicable.

The implementation in BiWeekly version 0.4.6 did not always return the expected value under certain circumstance. This became apparent when using the `advanceTo` method on a `DateIterator` with specific `startAt` and `TimeZone` values. See Issue #49 for an example.

The implementation of `TimeUtils.convert` in versions 0.4.5 and earlier does not contain this problem. However, a `DateIterator` in those earlier versions does not handle the DST "gap" hour correctly.  See Issue #38.