### PR TITLE
Keep UNTIL Date in UTC for comparison

### DIFF
--- a/src/main/java/biweekly/util/com/google/ical/iter/RecurrenceIteratorFactory.java
+++ b/src/main/java/biweekly/util/com/google/ical/iter/RecurrenceIteratorFactory.java
@@ -135,7 +135,9 @@ public class RecurrenceIteratorFactory {
 		DayOfWeek wkst = rrule.getWorkweekStarts();
 
 		ICalDate until = rrule.getUntil();
-		DateValue untilUtc = (until == null) ? null : Google2445Utils.convert(until, tzid);
+		
+		TimeZone utc = TimeZone.getTimeZone("UTC");
+		DateValue untilUtc = (until == null) ? null : Google2445Utils.convert(until, utc);
 
 		int count = toInt(rrule.getCount());
 		int interval = toInt(rrule.getInterval());

--- a/src/test/java/biweekly/util/com/google/ical/iter/CompoundIteratorImplTest.java
+++ b/src/test/java/biweekly/util/com/google/ical/iter/CompoundIteratorImplTest.java
@@ -428,7 +428,8 @@ public class CompoundIteratorImplTest {
 			new DateValueImpl(2006, 4, 28),
 			
 			new DateValueImpl(2006, 5, 1),
-			new DateValueImpl(2006, 5, 2)
+			new DateValueImpl(2006, 5, 2),
+			new DateValueImpl(2006, 5, 3)
 		), it);
 	}
 	
@@ -465,7 +466,8 @@ public class CompoundIteratorImplTest {
 				new DateValueImpl(2006, 4, 28),
 				
 				new DateValueImpl(2006, 5, 1),
-				new DateValueImpl(2006, 5, 2)
+				new DateValueImpl(2006, 5, 2),
+				new DateValueImpl(2006, 5, 3)
 		), it);
 	}
 	
@@ -497,7 +499,8 @@ public class CompoundIteratorImplTest {
 				new DateValueImpl(2006, 4, 28),
 				
 				new DateValueImpl(2006, 5, 1),
-				new DateValueImpl(2006, 5, 2)
+				new DateValueImpl(2006, 5, 2),
+				new DateValueImpl(2006, 5, 3)
 		), it);
 	}
 	


### PR DESCRIPTION
The problem occurs when the `UNTIL` date gets converted **from** UTC **to** the timezone specified when creating a `DateIterator`. When getting the next date from the `DateIterator`, the new date is converted **to** UTC and compared with the `UNTIL` (which is no longer in UTC). This results in the last event being outside of the window.

See example code snippet below:

```
RecurrenceRule recurrenceRule = vEvent.getRecurrenceRule();
if (recurrenceRule != null) {
    DateStart dateStart= vEvent.getDateStart();

    TimeZone timezone;
    if (tzInfo.isFloating(dateStart)){
        timezone = TimeZone.getDefault();
    } else {
        TimezoneAssignment dtstartTimezone = tzInfo.getTimezone(dateStart);
        timezone = (dtstartTimezone == null) ? TimeZone.getTimeZone("UTC") : dtstartTimezone.getTimeZone();
    }
    DateIterator iterator = vEvent.getDateIterator(timezone);
    
    while (iterator.hasNext()) {
        Date startDate = iterator.next();
        System.out.println(startDate.toString());
    }
}
```

```
BEGIN:VEVENT
DTSTART;TZID=America/New_York:20161219T090000
DTEND;TZID=America/New_York:20161219T100000
RRULE:FREQ=DAILY;UNTIL=20161223T140000Z
DTSTAMP:20161216T153224Z
UID:pdhtelaeqstgnbr9f0hrdioij0@google.com
CREATED:20161216T133749Z
DESCRIPTION:
LAST-MODIFIED:20161216T133749Z
LOCATION:
SEQUENCE:0
STATUS:CONFIRMED
SUMMARY:Daily Until 12/23
TRANSP:OPAQUE
END:VEVENT
```