### PR TITLE
Always use ENGLISH Locale for number formatting

### DIFF
--- a/src/main/java/biweekly/util/DateTimeComponents.java
+++ b/src/main/java/biweekly/util/DateTimeComponents.java
@@ -302,7 +302,7 @@ public final class DateTimeComponents implements Comparable<DateTimeComponents>,
 	public String toString(boolean includeTime, boolean extended) {
 		NumberFormat nf = NumberFormat.getNumberInstance(Locale.ENGLISH);
 		nf.setMinimumIntegerDigits(2);
-                nf.setMaximumIntegerDigits(2);
+		nf.setMaximumIntegerDigits(2);
 		String dash = extended ? "-" : "";
 		String colon = extended ? ":" : "";
 		String z = utc ? "Z" : "";

--- a/src/main/java/biweekly/util/DateTimeComponents.java
+++ b/src/main/java/biweekly/util/DateTimeComponents.java
@@ -1,10 +1,10 @@
 package biweekly.util;
 
 import java.io.Serializable;
-import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -300,7 +300,9 @@ public final class DateTimeComponents implements Comparable<DateTimeComponents>,
 	 * @return the date string
 	 */
 	public String toString(boolean includeTime, boolean extended) {
-		NumberFormat nf = new DecimalFormat("00");
+		NumberFormat nf = NumberFormat.getNumberInstance(Locale.ENGLISH);
+		nf.minimumIntegerDigits = 2;
+                nf.maximumIntegerDigits = 2;
 		String dash = extended ? "-" : "";
 		String colon = extended ? ":" : "";
 		String z = utc ? "Z" : "";

--- a/src/main/java/biweekly/util/DateTimeComponents.java
+++ b/src/main/java/biweekly/util/DateTimeComponents.java
@@ -301,8 +301,8 @@ public final class DateTimeComponents implements Comparable<DateTimeComponents>,
 	 */
 	public String toString(boolean includeTime, boolean extended) {
 		NumberFormat nf = NumberFormat.getNumberInstance(Locale.ENGLISH);
-		nf.minimumIntegerDigits = 2;
-                nf.maximumIntegerDigits = 2;
+		nf.setMinimumIntegerDigits(2);
+                nf.setMaximumIntegerDigits(2);
 		String dash = extended ? "-" : "";
 		String colon = extended ? ":" : "";
 		String z = utc ? "Z" : "";


### PR DESCRIPTION
Not able to correctly create iCal files on a device with an Arabic locale, as the DecimalFormat instance created uses different numerals.