### PR TITLE
Update README for changes in Gradle 3.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,8 @@ String str = Biweekly.write(ical).go();
 
 ```
 implementation 'net.sf.biweekly:biweekly:0.6.3'
+// or use the `api` keyword if you are exposing parts of biweekly in your API
 ```
-Or
-```
-api 'net.sf.biweekly:biweekly:0.6.3'
-```
-if you are exposing parts of `biweekly` as part of your API.
 
 # Build Instructions
 

--- a/README.md
+++ b/README.md
@@ -86,8 +86,13 @@ String str = Biweekly.write(ical).go();
 **Gradle**
 
 ```
-compile 'net.sf.biweekly:biweekly:0.6.3'
+implementation 'net.sf.biweekly:biweekly:0.6.3'
 ```
+Or
+```
+api 'net.sf.biweekly:biweekly:0.6.3'
+```
+if you are exposing parts of `biweekly` as part of your API.
 
 # Build Instructions
 


### PR DESCRIPTION
Gradle 3.0 replaces `compile` dependencies with `implementation` or `api` syntax. I am not sure if they have removed it yet, but it causes build warnings at the moment.

I've updated the README to reflect the usage of this new syntax.