### PR TITLE
Add automatic-module-name to manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,24 +156,17 @@
 				</configuration>
 			</plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                  <execution>
-                    <goals>
-                      <goal>test-jar</goal>
-                    </goals>
-                  </execution>
-                </executions>
-                <configuration>
-                  <archive>
-                    <manifestEntries>
-                      <Automatic-Module-Name>net.sf.biweekly</Automatic-Module-Name>
-                    </manifestEntries>
-                  </archive>
-                </configuration>
-              </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestEntries>
+							<Automatic-Module-Name>net.sf.biweekly</Automatic-Module-Name>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
 
 			<!-- Copy the project's dependencies into a folder -->
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,25 @@
 				</configuration>
 			</plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                  <execution>
+                    <goals>
+                      <goal>test-jar</goal>
+                    </goals>
+                  </execution>
+                </executions>
+                <configuration>
+                  <archive>
+                    <manifestEntries>
+                      <Automatic-Module-Name>net.sf.biweekly</Automatic-Module-Name>
+                    </manifestEntries>
+                  </archive>
+                </configuration>
+              </plugin>
+
 			<!-- Copy the project's dependencies into a folder -->
 			<plugin>
 				<artifactId>maven-dependency-plugin</artifactId>


### PR DESCRIPTION
This pull request will add the 'Automatic-Module-Name' field to the created MANIFEST.MF.

The automatic-module-name will be used by JPMS (Java Platform Module System, aka Jigsaw, present since Java 9) if no module-info.class file is present.
The additional field in manifest will not break any compatibility with the ancient Java 1.6 still used in this project.
